### PR TITLE
修复边栏错位问题

### DIFF
--- a/site.config
+++ b/site.config
@@ -1,5 +1,5 @@
 {
-    "version": 183,
+    "version": 185,
     "siteroot": "/",
     "dynamicRouter": "route",
     "Babel" : false,

--- a/tpl-e2/css/style.css
+++ b/tpl-e2/css/style.css
@@ -945,7 +945,7 @@ footer {
   .sidenav {
     position: fixed;
     height: 100%;
-    width: 270px;
+    width: 280px;
     z-index: 1;
     top: 0;
     left: 0;
@@ -1006,7 +1006,7 @@ footer {
   }
 }
 
-@media (max-height: 800px) {
+@media (max-height: 820px) {
   .bottom-social {
     margin-top: 30px;
     position: relative;


### PR DESCRIPTION
修复边栏在 surface pro 7 等小屏幕下面，边栏可能存在的错位问题。